### PR TITLE
Improve wildcard handling in the player parameter

### DIFF
--- a/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
+++ b/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
@@ -70,7 +70,7 @@ public class SearchQuery extends Thread {
 						npids.add(entry.getValue());
 					else if (name.contains(player.replace("*", "")))
 						pids.add(entry.getValue());
-                                        else if (name.contains(player.replace("!", "")))
+					else if (name.contains(player.replace("!", "")))
 						npids.add(entry.getValue());
 				}
 			}


### PR DESCRIPTION
This PR adds a more strict player parameter as requested in #31

The \* is used to override the strict player matching
