### PR TITLE
Adding REGEXP support for block searching

### DIFF
--- a/HawkEye Interface/interface.php
+++ b/HawkEye Interface/interface.php
@@ -137,13 +137,9 @@
 			$data["keywords"][$key] = "'%" . $val . "%'";
 		}
 		if($data["block"] != "00") //again, if a block, do a REGEXP
-        {
             array_push($args, "`data` REGEXP " . join(" OR `data` REGEXP ", $data["keywords"]));
-        }
 		else //if dealing with an entered string, do a LIKE seach with the already completed %% request
-        {
             array_push($args, "`data` LIKE " . join(" OR `data` LIKE ", $data["keywords"]));
-        }
 	}
 	if ($data["exclude"][0] != "") {
 		foreach ($data["exclude"] as $key => $val)


### PR DESCRIPTION
This is to evade the problem in which searching for Diamond Ore brought up Quartz Stairs.
In SQL syntax, %SEARCH_STRING%, % matches everything, even digits. Diamond ore is 56, Quartz Stairs 156
The provided example negates digits and some special symbols for quantity and after-id values to trim the results to the proper ones.
Note: This so far reduces a lot results when searching for both a keyword and a block, rarely used combination I hope.
