### PR TITLE
Fix bug that only lowercase players can be searched for.

### DIFF
--- a/src/uk/co/oliwali/HawkEye/SearchParser.java
+++ b/src/uk/co/oliwali/HawkEye/SearchParser.java
@@ -93,7 +93,7 @@ public class SearchParser {
 				String[] values = arg.split(",");
 
 				// Players
-				if (lastParam.equals("p")) for (String p : values) players.add(p.toLowerCase());
+				if (lastParam.equals("p")) for (String p : values) players.add(p);
 				// Worlds
 				else if (lastParam.equals("w")) worlds = values;
 				// Filters


### PR DESCRIPTION
All player-names got converted to lowercase, so only players that are completely lowercase, where able to be matched correctly. This bug affects only the "p:"-prefix, leaving the "p:" out matches also uppercase.

These two match the same player:
```
>he search p:lowercasename
[INFO]: Searching for matching results...
[INFO]: -------------------- Page (1/X) --------------------
[...]
[INFO]: ----------------------------------------------------
```
```
>he search p:LowerCaseNameInUpperCase
[INFO]: Searching for matching results...
[INFO]: -------------------- Page (1/X) --------------------
[...]
[INFO]: ----------------------------------------------------
```
What should have happened to the second one:
```
>he search LowerCaseNameInUpperCase
[INFO]: Searching for matching results...
[INFO]: No players found matching your specifications
```
Here is the bug:
```
>he search p:UpperCaseName
[INFO]: Searching for matching results...
[INFO]: No players found matching your specifications

```
```
>he search UpperCaseName
[INFO]: Searching for matching results...
[INFO]: ------------------- Page (1/X) -------------------
[...]
[INFO]: -----------------------------------------------------
```
