### PR TITLE
Bugfix in "/hawkeye delete"

### DIFF
--- a/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
+++ b/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
@@ -188,7 +188,7 @@ public class SearchQuery extends Thread {
         int deleted = 0;
 
         try (Connection conn = DataManager.getConnection();
-             PreparedStatement stmnt = conn.prepareStatement(sql.toString(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
+             PreparedStatement stmnt = conn.prepareStatement(sql.toString())) {
             //Execute query
 
             Util.debug("Preparing statement");

--- a/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
+++ b/src/uk/co/oliwali/HawkEye/database/SearchQuery.java
@@ -202,6 +202,7 @@ public class SearchQuery extends Thread {
             if (delete) {
                 Util.debug("Deleting entries");
                 deleted = stmnt.executeUpdate();
+                conn.commit();
             } else {
                 try (ResultSet res = stmnt.executeQuery()) {
 


### PR DESCRIPTION
The /ha delete command did not remove any entries, since the changes where never commited to the database.