### PR TITLE
Adding missing space to time feedback

### DIFF
--- a/src/uk/co/oliwali/HawkEye/util/Util.java
+++ b/src/uk/co/oliwali/HawkEye/util/Util.java
@@ -199,7 +199,7 @@ public class Util {
      * @return   Simplified date
      */
     public static String getTime(Date d1) {
-        if (!(Config.isSimpleTime)) return d1.toString();
+        if (!(Config.isSimpleTime)) return d1.toString() + " ";
 
         StringBuilder dateStr = new StringBuilder();
 


### PR DESCRIPTION
Happens if "simplify-time" is set to false. Full date and playername would stick together then.